### PR TITLE
Fix multiprocessing in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ env.sh: Makefile
 # automate compilation and installation of LibGme_m dependency
 $(LIBGME_M_RELPATH):
 	prefix=$(CURDIR)/pc/bin CROSS_COMPILE=$(CROSS_COMPILE) \
-	make -C submodules/libgme_m install-lib-direct
+	$(MAKE) -C submodules/libgme_m install-lib-direct
 clean-gme_m:
 	rm -f $(LIBGME_M_RELPATH)*
 
@@ -62,7 +62,7 @@ $(SPCDRIVER_RELPATH): snes_driver/spc.sym snes_driver/gen_spc.sh Makefile snes_d
 	cd snes_driver && wlaprefix=$(WLAPREFIX) ./gen_spc.sh ../$(SPCDRIVER_RELPATH)
 
 snes_driver/spc.sym: FORCE Makefile snes_driver/Makefile
-	make -C snes_driver
+	$(MAKE) -C snes_driver
 
 snes_driver/Makefile: snes_driver/genmake Makefile
 	cd snes_driver ; wlaprefix=$(WLAPREFIX) pcx2snes_prefix=$(PCX2SNES_PREFIX) ./genmake > Makefile
@@ -86,7 +86,7 @@ $(APURAM_HEADER): snes_driver/spc.sym Makefile \
 	# but I guess I'll keep it non-global..?
 
 $(EXE_TRACKER_RELPATH): FORCE pc/tracker/apuram.h $(LIBGME_M_RELPATH)
-	make -C pc
+	$(MAKE) -C pc
 
 FORCE: ;
 
@@ -94,7 +94,7 @@ clean: clean-gme_m
 	# remove generated files
 	rm -f $(APURAM_HEADER)
 	rm -f $(SPCDRIVER_RELPATH)
-	make -C pc clean
-	make -C snes_driver clean
-	make -C submodules/libgme_m clean
+	$(MAKE) -C pc clean
+	$(MAKE) -C snes_driver clean
+	$(MAKE) -C submodules/libgme_m clean
 	rm -f pc/bin/*.dll

--- a/pc/Makefile
+++ b/pc/Makefile
@@ -321,15 +321,15 @@ $(BIN)/$(DEC7Z): $(PROJ_DIR)/lzma1505/C/Util/7z/$(DEC7Z) $(PROJ_DIR)/lzma1505/C/
 	cp $(PROJ_DIR)/lzma1505/C/Util/7z/$(DEC7Z) $(BIN)
 
 $(PROJ_DIR)/lzma1505/C/Util/7z/$(DEC7Z):
-	uname_S=$(uname_S) make -C $(PROJ_DIR)/lzma1505/C/Util/7z -f makefile.gcc
+	uname_S=$(uname_S) $(MAKE) -C $(PROJ_DIR)/lzma1505/C/Util/7z -f makefile.gcc
 
 $(BIN)/$(UNRAR): $(PROJ_DIR)/unrar/$(UNRAR)
 	cp $(PROJ_DIR)/unrar/$(UNRAR) $(BIN)
 $(PROJ_DIR)/unrar/$(UNRAR):
-	uname_S=$(uname_S) make -C $(PROJ_DIR)/unrar
+	uname_S=$(uname_S) $(MAKE) -C $(PROJ_DIR)/unrar
 
 $(LIBJDKMIDI_LIB): $(LIBJDKMIDI_OSDIR)/Makefile
-	cd $(LIBJDKMIDI_OSDIR) && make
+	cd $(LIBJDKMIDI_OSDIR) && $(MAKE)
 
 $(LIBJDKMIDI_OSDIR)/Makefile:
 	cd $(LIBJDKMIDI_OSDIR) && osxflags="$(OSX_BACKSUPPORT)" ./configure
@@ -362,7 +362,7 @@ clean:
 	find . -name "*.o" -o -name "*.d" | xargs rm -rf
 	rm -f {$(PROJ_DIR)/lzma1505/C/Util/7z/,}{7zDec,7zDec.exe}
 	rm -f {$(PROJ_DIR)/unrar/,}{unrar,unrar.exe}
-	cd $(LIBJDKMIDI_OSDIR) && make clean
+	cd $(LIBJDKMIDI_OSDIR) && $(MAKE) clean
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 -include $(DEP_DEBUGGER) $(DEP_TRACKER)


### PR DESCRIPTION
Fixes `make`'s self-identification of recursive `make` calls in rules, required to fix multiprocessing (invoking `make` with e.g. `-j2`).

Warning when attempting to run e.g. `make -j2` on v0.2.0 (middle of execution):
```
make -C snes_driver
make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```

See [GNU make Error Message, Section "warning: jobserver unavailable: using -j1. Add \`+' to parent make rule."](https://www.gnu.org/software/make/manual/html_node/Error-Messages.html) and [How the `MAKE` Variable Works](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable).

Build time measurements via `time`:

unfixed, -j1
real	1m36,646s
user	1m20,740s
sys	0m15,071s

unfixed, -j6 (ignored by recursive make invocations, essentially -j1)
real	1m35,451s
user	1m19,411s
sys	0m15,300s

fixed, -j6
real	0m24,334s
user	1m48,657s
sys	0m19,671s