### PR TITLE
Update BaseD.cpp to fix compile issue on linux

### DIFF
--- a/pc/debugger/BaseD.cpp
+++ b/pc/debugger/BaseD.cpp
@@ -3,7 +3,8 @@
 #include "Menu_Bar.h"
 #include "File_System.h"
 #include "Instrument_Window.h"
-
+#include <algorithm>
+using namespace std;
 char BaseD::tmpbuf[500];
 
 


### PR DESCRIPTION
When compiling the project there is an issue on Linux based systems where gcc does not recognize the sort function that is called. This can be fixed by adding the two lines as seen in the diff.